### PR TITLE
Add Dependabot version updates and CodeQL scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "23 4 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml`: weekly version-update PRs for `docker` (the two `FROM debian:trixie-slim` stages) and `github-actions`. No `pip` ecosystem -- `ledfx` is installed via a bare `pip install ledfx` in the Dockerfile with no `requirements.txt`/lockfile for Dependabot to track. The `squeezelite` git submodule is already kept current by `check-submodule.yaml`'s own daily job -- Dependabot has no submodule ecosystem regardless.
- Adds `.github/workflows/codeql.yml`: CodeQL static analysis for Python (`startup.py`) on push/PR to `main` plus a weekly scheduled scan.
- Dependabot alerts and automated security-fix PRs were also enabled directly in repo settings (Settings > Code security).

## Test plan
- [ ] Merge and confirm the CodeQL workflow run appears green under Actions