### PR TITLE
Add the container scan step build.yml's own name promised

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,3 +86,29 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  scan:
+    # The "Scan" the workflow's own name promises -- image_tag (above) was already being
+    # computed for exactly this, but nothing ever consumed it. Scans the pushed GHCR image
+    # itself (base Debian packages, the vendored snapclient/snapserver .deb files, the
+    # pip-installed ledfx package), not just source, since that's where this repo's actual
+    # dependency surface lives. Public image, so no registry login needed to pull it here.
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}:${{ needs.build.outputs.image_tag }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: "0"
+
+      - name: Upload Trivy results to the Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary
`build.yml` is named "Build_Push_Scan" and already declares `security-events: write` plus a `build` job output (`image_tag`) explicitly commented "to pass to the scan job" -- but no scan job existed. Adds one: Trivy scans the pushed GHCR image (base Debian packages, the vendored `.deb` files, pip-installed `ledfx`), uploading CRITICAL/HIGH findings as SARIF to the Security tab. `exit-code: "0"` so a finding doesn't fail the build -- informational, same treatment as CodeQL.

## Test plan
- [ ] Merge, push to main, confirm the `scan` job runs after `build` and completes
- [ ] Confirm results (if any) show up under the Security tab's code scanning alerts